### PR TITLE
Feature addition: add login name to role assumption

### DIFF
--- a/assumer.go
+++ b/assumer.go
@@ -1,2 +1,0 @@
-// Package assumer for library code
-package assumer

--- a/cmd/assumer/helpers.go
+++ b/cmd/assumer/helpers.go
@@ -14,7 +14,7 @@ import (
 	"github.com/fatih/color"
 )
 
-// generates the GUI console URL
+// GUIURL generates the GUI console URL
 func GUIURL(t *sts.AssumeRoleOutput) string {
 	signinURL := "https://signin.aws.amazon.com/federation"
 	issuer := "assumer"
@@ -22,7 +22,7 @@ func GUIURL(t *sts.AssumeRoleOutput) string {
 
 	// anonymous struct for marshalling data into JSON
 	session := struct {
-		SessionId    string `json:"sessionId"`
+		SessionID    string `json:"sessionId"`
 		SessionKey   string `json:"sessionKey"`
 		SessionToken string `json:"sessionToken"`
 	}{

--- a/cmd/assumer/version.go
+++ b/cmd/assumer/version.go
@@ -2,8 +2,8 @@ package main
 
 import "fmt"
 
-const semver = "0.0.5"
+const semver = "0.0.6"
 
 func printVersion() {
-	fmt.Printf("VERSION: %s\n\n", semver)
+	fmt.Printf("VERSION: %s\n", semver)
 }

--- a/target.go
+++ b/target.go
@@ -2,6 +2,8 @@ package assumer
 
 import (
 	"errors"
+	"fmt"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -24,7 +26,7 @@ func (t *TargetPlane) Assume(c *sts.AssumeRoleOutput) (*sts.AssumeRoleOutput, er
 
 	targetParams := &sts.AssumeRoleInput{
 		RoleArn:         aws.String(t.Plane.RoleArn),
-		RoleSessionName: aws.String("AssumedRole"),
+		RoleSessionName: aws.String(fmt.Sprintf("%s_AssumedRole", os.Getenv("USER"))),
 	}
 
 	controlCreds := credentials.NewStaticCredentials(*c.Credentials.AccessKeyId, *c.Credentials.SecretAccessKey, *c.Credentials.SessionToken)


### PR DESCRIPTION
This PR adds the user's name to the role session name when a role is assumed. This helps to keep track of who is assuming roles across which accounts.